### PR TITLE
replace tmp file read with curl in examples

### DIFF
--- a/cloudflare-ufw.sh
+++ b/cloudflare-ufw.sh
@@ -7,10 +7,10 @@ ufw reload > /dev/null
 
 # OTHER EXAMPLE RULES
 # Restrict to port 80
-#for cfip in `cat /tmp/cf_ips`; do ufw allow proto tcp from $cfip to any port 80 comment 'Cloudflare IP'; done
+#for cfip in `curl -sw '\n' https://www.cloudflare.com/ips-v{4,6}`; do ufw allow proto tcp from $cfip to any port 80 comment 'Cloudflare IP'; done
 
 # Restrict to port 443
-#for cfip in `cat /tmp/cf_ips`; do ufw allow proto tcp from $cfip to any port 443 comment 'Cloudflare IP'; done
+#for cfip in `curl -sw '\n' https://www.cloudflare.com/ips-v{4,6}`; do ufw allow proto tcp from $cfip to any port 443 comment 'Cloudflare IP'; done
 
 # Restrict to ports 80 & 443
-#for cfip in `cat /tmp/cf_ips`; do ufw allow proto tcp from $cfip to any port 80,443 comment 'Cloudflare IP'; done
+#for cfip in `curl -sw '\n' https://www.cloudflare.com/ips-v{4,6}`; do ufw allow proto tcp from $cfip to any port 80,443 comment 'Cloudflare IP'; done


### PR DESCRIPTION
Hey!
I noticed the other examples in the script are still using the /tmp/cf_ips file. 
I replaced them with the curl command.

