### PR TITLE
Remove UFW rules with the comment 'Cloudflare IP' to clean up old configurations.

### DIFF
--- a/cloudflare-ufw.sh
+++ b/cloudflare-ufw.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Delete existing rules with the comment 'Cloudflare IP'
+ufw status numbered | grep 'Cloudflare IP' | sed -E 's/^\[ *([0-9]+)\].*/\1/' | sort -nr | while read -r rule ; do ufw --force delete "$rule"; done
+
 # Allow all traffic from Cloudflare IPs (no ports restriction)
 for cfip in `curl -sw '\n' https://www.cloudflare.com/ips-v{4,6}`; do ufw allow proto tcp from $cfip comment 'Cloudflare IP'; done
 


### PR DESCRIPTION
This PR removes existing UFW rules that contain the comment 'Cloudflare IP' to clean up outdated configurations.

